### PR TITLE
Add basic playlist class and mac command-line support

### DIFF
--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -152,6 +152,7 @@ add_executable(tracker
     TrackerUpdate.cpp
     Undo.cpp
     VRand.cpp
+    Playlist.cpp
     Zapper.cpp
 
     # Headers
@@ -240,6 +241,7 @@ add_executable(tracker
     TrackerSettingsDatabase.h
     Undo.h
     VRand.h
+    Playlist.h
     Zapper.h
 )
 

--- a/src/tracker/Playlist.cpp
+++ b/src/tracker/Playlist.cpp
@@ -1,0 +1,69 @@
+#include "Playlist.h"
+#include <fstream>
+#include <algorithm>
+
+bool Playlist::loadFromFile(const std::string& path) {
+    std::ifstream in(path.c_str());
+    if (!in.is_open())
+        return false;
+    entries.clear();
+    std::string line;
+    while (std::getline(in, line)) {
+        if (!line.empty())
+            entries.push_back(line);
+    }
+    currentIndex = 0;
+    return true;
+}
+
+bool Playlist::saveToFile(const std::string& path) const {
+    std::ofstream out(path.c_str());
+    if (!out.is_open())
+        return false;
+    for (const auto& e : entries)
+        out << e << "\n";
+    return true;
+}
+
+void Playlist::add(const std::string& entry) {
+    entries.push_back(entry);
+}
+
+void Playlist::remove(size_t index) {
+    if (index < entries.size()) {
+        entries.erase(entries.begin() + index);
+        if (currentIndex >= entries.size())
+            currentIndex = entries.empty() ? 0 : entries.size() - 1;
+    }
+}
+
+void Playlist::clear() {
+    entries.clear();
+    currentIndex = 0;
+}
+
+const std::string& Playlist::current() const {
+    static const std::string empty;
+    if (entries.empty())
+        return empty;
+    return entries[currentIndex];
+}
+
+bool Playlist::next() {
+    if (currentIndex + 1 >= entries.size())
+        return false;
+    ++currentIndex;
+    return true;
+}
+
+bool Playlist::previous() {
+    if (currentIndex == 0)
+        return false;
+    --currentIndex;
+    return true;
+}
+
+void Playlist::setIndex(size_t idx) {
+    if (idx < entries.size())
+        currentIndex = idx;
+}

--- a/src/tracker/Playlist.h
+++ b/src/tracker/Playlist.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Playlist {
+public:
+    // Load playlist from a text file (one path per line)
+    bool loadFromFile(const std::string& path);
+
+    // Save playlist to a text file
+    bool saveToFile(const std::string& path) const;
+
+    // Add a new entry
+    void add(const std::string& entry);
+
+    // Remove entry at index
+    void remove(size_t index);
+
+    // Clear playlist
+    void clear();
+
+    // Get current entry
+    const std::string& current() const;
+
+    // Move to next entry; returns false if at end
+    bool next();
+
+    // Move to previous entry; returns false if at beginning
+    bool previous();
+
+    size_t size() const { return entries.size(); }
+    size_t index() const { return currentIndex; }
+    void setIndex(size_t idx);
+
+    const std::vector<std::string>& getEntries() const { return entries; }
+
+private:
+    std::vector<std::string> entries;
+    size_t currentIndex = 0;
+};

--- a/src/tracker/cocoa/main.mm
+++ b/src/tracker/cocoa/main.mm
@@ -32,6 +32,7 @@
 #import <XModule.h>
 #import <WAVExporter.h>
 #import <CLIParser.h>
+#import "Playlist.h"
 #import "AppDelegate.h"
 
 // ----------------------------------------------------------
@@ -65,8 +66,9 @@ void QueryKeyModifiers() { }
 int main(int argc, const char * argv[])
 {
 	static CLIParser parser(argc, argv);
-	parser.addPositionalArg("input", "Input module file (.xm)", false);
-	parser.addOption("-headless", false, "Run in headless mode");
+        parser.addPositionalArg("input", "Input module file (.xm)", false);
+        parser.addOption("-headless", false, "Run in headless mode");
+        parser.addOption("-playlist", true, "Path to playlist file");
 
 	auto exporter = WAVExporter::createFromParser(parser);
 
@@ -76,8 +78,16 @@ int main(int argc, const char * argv[])
 		return 1;
 	}
 
-	const char* inputFile = parser.getPositionalArg(0);
-	const char* outputWAVFile = parser.getOptionValue("-output");
+        const char* inputFile = parser.getPositionalArg(0);
+        const char* outputWAVFile = parser.getOptionValue("-output");
+        const char* playlistFile = parser.getOptionValue("-playlist");
+        Playlist playlist;
+        if (playlistFile) {
+                if (playlist.loadFromFile(playlistFile) && playlist.size() > 0) {
+                        parser.setPositionalArgValue(0, playlist.current().c_str());
+                        inputFile = parser.getPositionalArg(0);
+                }
+        }
 
 	if (inputFile && outputWAVFile) {
 		if (exporter->hasArgumentError()) {


### PR DESCRIPTION
## Summary
- introduce a simple `Playlist` class for loading and saving lists of module files
- build playlist into tracker executable via CMake
- extend macOS `main.mm` to accept `-playlist` option and load the first entry

## Testing
- `cmake ..` *(fails: SDL2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840805f7c4c83299c5da4a69eef08a7