### PR TITLE
Fix build warnings in Limiter

### DIFF
--- a/src/milkyplay/Limiter.h
+++ b/src/milkyplay/Limiter.h
@@ -183,12 +183,6 @@ struct Limiter : public Mixable
       buffer_pos++;
 
     }
-    buffer_pos = buffer_pos;
-    peak = peak;
-    atten = atten;
-    atten_lp = atten_lp;
-    chunk_pos = chunk_pos;
-    chunk_num = chunk_num;
     //*(plugin_data->attenuation) = -CO_DB(atten);
     //*(plugin_data->latency) = delay;
   }


### PR DESCRIPTION
## Summary
- remove redundant assignments in `Limiter::mix`

## Testing
- `cmake -B build -S .` *(fails: Could not find package SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6842d239a12c8329bd0e4704ba9ce0b5