### PR TITLE
Replace sprintf usages with snprintf

### DIFF
--- a/src/compression/PP20.cpp
+++ b/src/compression/PP20.cpp
@@ -373,7 +373,7 @@ pp_int32 PP20::ppcrack(pp_uint8** destRef, pp_uint8 *data, pp_uint32 len)
 				ppDecrunch(temp, output, &data[6], len-14, outlen, data[len-1]);
 				
 				/* key_match = key */
-				/* sprintf(output_name, "%s.%08x", name, key); */
+				/* snprintf(output_name, sizeof(output_name), "%s.%08x", name, key); */
 				
 				savefile(fo, output, outlen);
 				break;

--- a/src/milkyplay/LoaderPSM.cpp
+++ b/src/milkyplay/LoaderPSM.cpp
@@ -253,7 +253,7 @@ mp_sint32 LoaderPSMv2::load(XMFileBase& f, XModule* module)
 						else
 						{
 							char patSig[10];
-							sprintf(patSig, "P%i  ", patIndex % 999);
+							snprintf(patSig, sizeof(patSig), "P%i  ", patIndex % 999);
 						
 							patterns[patIndex] = new mp_ubyte[20];
 							memset(patterns[patIndex],0,20);

--- a/src/ppui/DictionaryKey.cpp
+++ b/src/ppui/DictionaryKey.cpp
@@ -58,7 +58,7 @@ void PPDictionaryKey::store(const pp_uint32 value)
 {
 	char buffer[100];
 	
-	sprintf(buffer,"%i",value);
+	snprintf(buffer, sizeof(buffer),"%i",value);
 	
 	this->value = buffer;
 }

--- a/src/ppui/ListBoxFileBrowser.cpp
+++ b/src/ppui/ListBoxFileBrowser.cpp
@@ -336,16 +336,16 @@ void PPListBoxFileBrowser::appendFileSize(PPString& name, const PPPathEntry& ent
 		char buffer[1024];
 		
 		if (size < 1024)
-			sprintf(buffer, " (%db)", (pp_int32)size);
+			snprintf(buffer, sizeof(buffer), " (%db)", (pp_int32)size);
 		else if (size < 1024*1024)
 		{
 			size>>=10;
-			sprintf(buffer, " (%dkb)", (pp_int32)size);
+			snprintf(buffer, sizeof(buffer), " (%dkb)", (pp_int32)size);
 		}
 		else
 		{
 			size>>=20;
-			sprintf(buffer, " (%dmb)", (pp_int32)size);
+			snprintf(buffer, sizeof(buffer), " (%dmb)", (pp_int32)size);
 		}
 	
 		name.append(buffer);

--- a/src/tools/fontcompiler.cpp
+++ b/src/tools/fontcompiler.cpp
@@ -447,7 +447,7 @@ int main(int argc, const char* argv[])
 						dst = src;
 				
 					char hexStr[100];
-					sprintf(hexStr, "\\x%x", dst);
+					snprintf(hexStr, sizeof(hexStr), "\\x%x", dst);
 				
 					if (i == size - 1)
 						f << hexStr << '"' << endl;

--- a/src/tracker/DialogEQ.cpp
+++ b/src/tracker/DialogEQ.cpp
@@ -59,7 +59,7 @@ DialogEQ::DialogEQ(PPScreen* screen,
 	
 	char dummy[100];
 	
-	sprintf(dummy, "%i Band Equalizer" PPSTR_PERIODS, numSliders);
+	snprintf(dummy, sizeof(dummy), "%i Band Equalizer" PPSTR_PERIODS, numSliders);
 	
 	initDialog(screen, responder, id, dummy, 300, 230, 26, "Ok", "Cancel");
 
@@ -91,7 +91,7 @@ DialogEQ::DialogEQ(PPScreen* screen,
 		PPFont* font = PPFont::getFont(PPFont::FONT_TINY);
 		char dummy[100];
 		pp_int32 value = (pp_int32)values[i];
-		sprintf(dummy, value >= 1000 ? "%ik" : "%i", value >= 1000 ? value / 1000 : value);
+		snprintf(dummy, sizeof(dummy), value >= 1000 ? "%ik" : "%i", value >= 1000 ? value / 1000 : value);
 		PPStaticText* staticText = new PPStaticText(0, screen, this, PPPoint(x2 + (SCROLLBUTTONSIZE/2) - font->getStrWidth(dummy) / 2, y2 - 8), dummy, true);
 		staticText->setFont(font);
 		getMessageBoxContainer()->addControl(staticText);
@@ -123,7 +123,7 @@ DialogEQ::DialogEQ(PPScreen* screen,
 		PPFont* font = PPFont::getFont(PPFont::FONT_TINY);
 	
 		char dummy[100];
-		sprintf(dummy, j < 4 ? "+%i dB" : "%i dB", (8-j)*3 - 12);
+		snprintf(dummy, sizeof(dummy), j < 4 ? "+%i dB" : "%i dB", (8-j)*3 - 12);
 		PPStaticText* staticText = new PPStaticText(0, screen, this, PPPoint(x2 + font->getStrWidth("+12 dB") - font->getStrWidth(dummy), (pp_int32)y2f), dummy, true);
 		staticText->setFont(font);
 		getMessageBoxContainer()->addControl(staticText);

--- a/src/tracker/DialogHelp.cpp
+++ b/src/tracker/DialogHelp.cpp
@@ -99,7 +99,7 @@ DialogHelp::DialogHelp(PPScreen *screen,
 	// uncomment to display all characters
 	//for( c = 0; c <128; c++ ){
 	//  char msg[255];
-	//  sprintf(msg,"d=%d x=%x %c\n",c,c,c);
+	//  snprintf(msg, sizeof(msg),"d=%d x=%x %c\n",c,c,c);
 	//  listBox->addItem( msg );
 	//  
 	//}

--- a/src/tracker/DialogPanning.cpp
+++ b/src/tracker/DialogPanning.cpp
@@ -139,7 +139,7 @@ void DialogPanning::init()
 		slider->setBarSize(16384);
 		messageBoxContainerGeneric->addControl(slider);
 
-		sprintf(buffer, "Ch:%02d L         R", i+1);
+		snprintf(buffer, sizeof(buffer), "Ch:%02d L         R", i+1);
 		messageBoxContainerGeneric->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x + 4, y2), buffer, true));
 
 		y2+=12;
@@ -155,7 +155,7 @@ void DialogPanning::init()
 		slider->setBarSize(16384);
 		messageBoxContainerGeneric->addControl(slider);
 
-		sprintf(buffer, "Ch:%02d L         R", i+1+(maxChannels/2));
+		snprintf(buffer, sizeof(buffer), "Ch:%02d L         R", i+1+(maxChannels/2));
 		messageBoxContainerGeneric->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x2 + 4, y2), buffer, true));
 
 		y2+=12;

--- a/src/tracker/DialogQuickChooseInstrument.cpp
+++ b/src/tracker/DialogQuickChooseInstrument.cpp
@@ -303,14 +303,14 @@ void DialogQuickChooseInstrument::fitListBox(pp_int32 id, pp_int32 valueOneRange
 	char buffer1[100];
 	char buffer2[100];
 
-	sprintf(buffer1, "%%x");
+	snprintf(buffer1, sizeof(buffer1), "%%x");
 
 	PPListBox* listBox = static_cast<PPListBox*>(messageBoxContainerGeneric->getControlByID(id));
 	if (listBox)
 	{
-		sprintf(buffer2, buffer1, valueRangeStart);
+		snprintf(buffer2, sizeof(buffer2), buffer1, valueRangeStart);
 		pp_int32 len = (pp_int32)strlen(buffer2)+1;
-		sprintf(buffer2, buffer1,  valueRangeEnd);
+		snprintf(buffer2, sizeof(buffer2), buffer1,  valueRangeEnd);
 		if ((pp_int32)strlen(buffer2)+1 > len) len = (pp_int32)strlen(buffer2)+1;
 		
 		pp_int32 y2 = listBox->getLocation().y;
@@ -343,12 +343,12 @@ void DialogQuickChooseInstrument::updateListBox(pp_int32 id, pp_int32 val)
 	char buffer1[100];
 	char buffer2[100];
 
-	sprintf(buffer1, "%%x");
+	snprintf(buffer1, sizeof(buffer1), "%%x");
 
 	PPListBox* listBox = static_cast<PPListBox*>(messageBoxContainerGeneric->getControlByID(id));
 	if (listBox)
 	{
-		sprintf(buffer2, buffer1, val);
+		snprintf(buffer2, sizeof(buffer2), buffer1, val);
 		listBox->clear();
 		listBox->addItem(buffer2);
 	}

--- a/src/tracker/DialogResample.cpp
+++ b/src/tracker/DialogResample.cpp
@@ -450,12 +450,12 @@ void DialogResample::updateListBox(pp_int32 id, float val, pp_int32 numDecimals)
 	char buffer1[100];
 	char buffer2[100];
 
-	sprintf(buffer1, "%%.%if", numDecimals);
+	snprintf(buffer1, sizeof(buffer1), "%%.%if", numDecimals);
 
 	PPListBox* listBox = static_cast<PPListBox*>(messageBoxContainerGeneric->getControlByID(id));
 	if (listBox)
 	{
-		sprintf(buffer2, buffer1, val);
+		snprintf(buffer2, sizeof(buffer2), buffer1, val);
 		listBox->clear();
 		listBox->addItem(buffer2);
 	}

--- a/src/tracker/DialogSliders.cpp
+++ b/src/tracker/DialogSliders.cpp
@@ -84,7 +84,7 @@ void DialogSliders::initSlider(int i, float min, float max, float value, PPStrin
 	getMessageBoxContainer()->addControl(staticText);
 	// value
 	char v[255];
-	sprintf(v,"%i",(int)value);
+	snprintf(v, sizeof(v),"%i",(int)value);
 	//staticText = new PPStaticText(MESSAGEBOX_CONTROL_USER1+TEXTVALUES_OFFSET+i, screen, this, PPPoint(x+width-(4*12), y2), v, true);
 	//staticText->setFont(font);
 	//getMessageBoxContainer()->addControl(staticText);
@@ -118,7 +118,7 @@ pp_int32 DialogSliders::handleEvent(PPObject* sender, PPEvent* event)
   if( id >= MESSAGEBOX_CONTROL_USER1 && id <= MESSAGEBOX_CONTROL_USER1+numSliders ){
     pp_uint32 slider = id-MESSAGEBOX_CONTROL_USER1;
     float val = getSlider( slider );
-    sprintf(v,"%i",(int)val);
+    snprintf(v, sizeof(v),"%i",(int)val);
     listBoxes[slider]->updateItem( 0, PPString(v) );
     listBoxes[slider]->commitChanges();
     needUpdate = true;

--- a/src/tracker/DialogWithValues.cpp
+++ b/src/tracker/DialogWithValues.cpp
@@ -314,14 +314,14 @@ void DialogWithValues::fitListBox(pp_int32 id, float valueOneRangeStart, float v
 	char buffer1[100];
 	char buffer2[100];
 
-	sprintf(buffer1, "%%.%if", numDecimals);
+	snprintf(buffer1, sizeof(buffer1), "%%.%if", numDecimals);
 
 	PPListBox* listBox = static_cast<PPListBox*>(messageBoxContainerGeneric->getControlByID(id));
 	if (listBox)
 	{
-		sprintf(buffer2, buffer1, valueOneRangeStart);
+		snprintf(buffer2, sizeof(buffer2), buffer1, valueOneRangeStart);
 		pp_int32 len = (pp_int32)strlen(buffer2);
-		sprintf(buffer2, buffer1,  valueOneRangeEnd);
+		snprintf(buffer2, sizeof(buffer2), buffer1,  valueOneRangeEnd);
 		if ((pp_int32)strlen(buffer2) > len) len = (pp_int32)strlen(buffer2);
 		
 		pp_int32 y2 = listBox->getLocation().y;
@@ -355,12 +355,12 @@ void DialogWithValues::updateListBox(pp_int32 id, float val, pp_int32 numDecimal
 	char buffer1[100];
 	char buffer2[100];
 
-	sprintf(buffer1, "%%.%if", numDecimals);
+	snprintf(buffer1, sizeof(buffer1), "%%.%if", numDecimals);
 
 	PPListBox* listBox = static_cast<PPListBox*>(messageBoxContainerGeneric->getControlByID(id));
 	if (listBox)
 	{
-		sprintf(buffer2, buffer1, val);
+		snprintf(buffer2, sizeof(buffer2), buffer1, val);
 		listBox->clear();
 		listBox->addItem(buffer2);
 	}

--- a/src/tracker/ModuleServices.cpp
+++ b/src/tracker/ModuleServices.cpp
@@ -126,7 +126,7 @@ pp_int32 ModuleServices::exportToWAV(const PPSystemString& fileName, WAVWriterPa
 			PPSystemString fileName = baseName;
 			
 			char infix[80];
-			sprintf(infix, "_%02d", i+1);
+			snprintf(infix, sizeof(infix), "_%02d", i+1);
 			
 			fileName.append(infix);
 			fileName.append(extension);

--- a/src/tracker/PatternEditorControl.cpp
+++ b/src/tracker/PatternEditorControl.cpp
@@ -481,7 +481,7 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 				}
 			}
 
-			sprintf(name, "%i", j+1);
+			snprintf(name, sizeof(name), "%i", j+1);
 
 			if (muteChannels[j])
 				strcat(name, " <Mute>");

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -1755,7 +1755,7 @@ void PatternEditorControl::updateStatus()
 		case 1: 
 		case 2: op = patternTools.getInstrument();
 				if( op > 0 ){
-					sprintf(label, op > 0 ? "%i" : "",op); 
+					snprintf(label, sizeof(label), op > 0 ? "%i" : "",op); 
 					status = label;
 				}
 				break;  // to vol-cmd
@@ -1788,56 +1788,56 @@ void PatternEditorControl::updateStatus()
 					op2 = patternTools.getNibble( op, PatternEditor::NibbleTypeLow );
 					patternTools.getEffectName( fxchar, eff);
 					if( eff != 0 ){
-						sprintf(label,"%i",op);
+						snprintf(label, sizeof(label),"%i",op);
 						status = PPString(label);
 
 						switch( fxchar[0] ){
-							case '0': sprintf(label,"semitone offset%c", param); break;
-							case '1': sprintf(label,"porta up speed");   break;
-							case '2': sprintf(label,"porta down speed"); break;
-							case '3': sprintf(label,"porta note speed"); break;
-							case '4': sprintf(label,"vibrato %s",        param == '1' ? "speed" : "depth" ); break;
-							case '5': sprintf(label,"portafade %s", param == '1' ? "up" : "down" ); break;
-							case '6': sprintf(label,"vibrafade %s", param == '1' ? "up" : "down" ); break;
-							case '7': sprintf(label,"tremolo  %s",       param == '1' ? "speed" : "depth" ); break;
-							case '8': sprintf(label,"pan 0=left ff=right");  break;
-							case '9': sprintf(label,"samplestart 0-FF"); break;
-							case 'A': sprintf(label,"fade speed %s",     isFX1 ? " " : param == '1' ? "up" : "down" ); break;
-							case 'B': sprintf(label,"song position");    break;
-							case 'C': sprintf(label,"note volume");      break;
-							case 'D': sprintf(label,"row next pattern"); break;
+							case '0': snprintf(label, sizeof(label),"semitone offset%c", param); break;
+							case '1': snprintf(label, sizeof(label),"porta up speed");   break;
+							case '2': snprintf(label, sizeof(label),"porta down speed"); break;
+							case '3': snprintf(label, sizeof(label),"porta note speed"); break;
+							case '4': snprintf(label, sizeof(label),"vibrato %s",        param == '1' ? "speed" : "depth" ); break;
+							case '5': snprintf(label, sizeof(label),"portafade %s", param == '1' ? "up" : "down" ); break;
+							case '6': snprintf(label, sizeof(label),"vibrafade %s", param == '1' ? "up" : "down" ); break;
+							case '7': snprintf(label, sizeof(label),"tremolo  %s",       param == '1' ? "speed" : "depth" ); break;
+							case '8': snprintf(label, sizeof(label),"pan 0=left ff=right");  break;
+							case '9': snprintf(label, sizeof(label),"samplestart 0-FF"); break;
+							case 'A': snprintf(label, sizeof(label),"fade speed %s",     isFX1 ? " " : param == '1' ? "up" : "down" ); break;
+							case 'B': snprintf(label, sizeof(label),"song position");    break;
+							case 'C': snprintf(label, sizeof(label),"note volume");      break;
+							case 'D': snprintf(label, sizeof(label),"row next pattern"); break;
 							case 'E': {
 										  switch( op1 ){
-											case 1: sprintf(label, param == '1' ? "fine porta up" : "fporta speed"); break;
-											case 2: sprintf(label, param == '1' ? "fine porta down" : "fporta speed"); break;
-											case 3: sprintf(label, param == '1' ? "glissando" : "not supported"); break;
-											case 4: sprintf(label, param == '1' ? "vibrato control" : "not supported"); break;
-											case 5: sprintf(label, param == '1' ? "note fine-tune" : "fine-tune value"); break;
-											case 6: sprintf(label, param == '1' ? "pattern loop" : "pattern loop start=0 / times"); break;
-											case 7: sprintf(label, param == '1' ? "tremolo control" : "not supported"); break;
-											case 8: sprintf(label, param == '1' ? "note pan pos" : "dont use this"); break;
-											case 9: sprintf(label, param == '1' ? "retrigger note" : "retrigger interval"); break;
-											case 10: sprintf(label, param == '1' ? "fine fade up" : "finefade speed"); break;
-											case 11: sprintf(label, param == '1' ? "fine fade down" : "finefade speed"); break;
-											case 12: sprintf(label, param == '1' ? "note cut" : "note cut tick number"); break;
-											case 13: sprintf(label, param == '1' ? "note delay" : "note cut tick number"); break;
-											case 14: sprintf(label, param == '1' ? "pattern delay" : "pattern delay rows"); break;
-											default: sprintf(label,"not supported"); break;
+											case 1: snprintf(label, sizeof(label), param == '1' ? "fine porta up" : "fporta speed"); break;
+											case 2: snprintf(label, sizeof(label), param == '1' ? "fine porta down" : "fporta speed"); break;
+											case 3: snprintf(label, sizeof(label), param == '1' ? "glissando" : "not supported"); break;
+											case 4: snprintf(label, sizeof(label), param == '1' ? "vibrato control" : "not supported"); break;
+											case 5: snprintf(label, sizeof(label), param == '1' ? "note fine-tune" : "fine-tune value"); break;
+											case 6: snprintf(label, sizeof(label), param == '1' ? "pattern loop" : "pattern loop start=0 / times"); break;
+											case 7: snprintf(label, sizeof(label), param == '1' ? "tremolo control" : "not supported"); break;
+											case 8: snprintf(label, sizeof(label), param == '1' ? "note pan pos" : "dont use this"); break;
+											case 9: snprintf(label, sizeof(label), param == '1' ? "retrigger note" : "retrigger interval"); break;
+											case 10: snprintf(label, sizeof(label), param == '1' ? "fine fade up" : "finefade speed"); break;
+											case 11: snprintf(label, sizeof(label), param == '1' ? "fine fade down" : "finefade speed"); break;
+											case 12: snprintf(label, sizeof(label), param == '1' ? "note cut" : "note cut tick number"); break;
+											case 13: snprintf(label, sizeof(label), param == '1' ? "note delay" : "note cut tick number"); break;
+											case 14: snprintf(label, sizeof(label), param == '1' ? "pattern delay" : "pattern delay rows"); break;
+											default: snprintf(label, sizeof(label),"not supported"); break;
 										  }
 										  break;
 									  }
-							case 'F': sprintf(label,"spd < 20 > bpm"); break;
-							case 'G': sprintf(label,"global volume"); break;
-							case 'H': sprintf(label,"global fade %s", param == '1' ? "up" : "down"); break;
-							case 'L': sprintf(label,"envelope tick"); break;
-							case 'P': sprintf(label,"pan speed %s", isFX1 ? " " : param == '1' ? "R" : "L"); break;
-							case 'R': sprintf(label,"%s", param == '1' ? "retrig volfade speed" : "retrigger interval"); break;
-							case 'T': sprintf(label,"%s", param == '1' ? "tremor ticks on" : "tremor ticks off"); break;
+							case 'F': snprintf(label, sizeof(label),"spd < 20 > bpm"); break;
+							case 'G': snprintf(label, sizeof(label),"global volume"); break;
+							case 'H': snprintf(label, sizeof(label),"global fade %s", param == '1' ? "up" : "down"); break;
+							case 'L': snprintf(label, sizeof(label),"envelope tick"); break;
+							case 'P': snprintf(label, sizeof(label),"pan speed %s", isFX1 ? " " : param == '1' ? "R" : "L"); break;
+							case 'R': snprintf(label, sizeof(label),"%s", param == '1' ? "retrig volfade speed" : "retrigger interval"); break;
+							case 'T': snprintf(label, sizeof(label),"%s", param == '1' ? "tremor ticks on" : "tremor ticks off"); break;
 							case 'X': {
 										  switch( op1 ){
-											case 1: sprintf(label,"%s", param == '1' ? "xfine porta up" : "speed"); break;
-											case 2: sprintf(label,"%s", param == '1' ? "xfine porta down" : "speed"); break;
-											default: sprintf(label,"not supported"); break;
+											case 1: snprintf(label, sizeof(label),"%s", param == '1' ? "xfine porta up" : "speed"); break;
+											case 2: snprintf(label, sizeof(label),"%s", param == '1' ? "xfine porta down" : "speed"); break;
+											default: snprintf(label, sizeof(label),"not supported"); break;
 										  }
 										  break;
 									  }

--- a/src/tracker/PatternEditorControlTransposeHandler.cpp
+++ b/src/tracker/PatternEditorControlTransposeHandler.cpp
@@ -40,7 +40,7 @@ void PatternEditorControl::showNoteTransposeWarningMessageBox(pp_int32 fuckups)
 	}
 	
 	char buffer[100];
-	sprintf(buffer, "%i notes will be erased, continue?", fuckups);
+	snprintf(buffer, sizeof(buffer), "%i notes will be erased, continue?", fuckups);
 	
 	dialog = new PPDialogBase(parentScreen, transposeHandlerResponder, PP_DEFAULT_ID, buffer);
 	dialog->show();

--- a/src/tracker/PatternTools.cpp
+++ b/src/tracker/PatternTools.cpp
@@ -833,29 +833,29 @@ pp_uint8 PatternTools::getNibble(pp_int32 op, PatternEditor::NibbleTypes type)
 
 void PatternTools::getEffectDescription(char* label, char fxchar){
 	switch( fxchar ){
-		case '0': sprintf(label,"arp"); break; 
-		case '1': sprintf(label,"portup"); break; 
-		case '2': sprintf(label,"portdown"); break; 
-		case '3': sprintf(label,"portnote"); break; 
-		case '4': sprintf(label,"vibrato"); break; 
-		case '5': sprintf(label,"portafade"); break; 
-		case '6': sprintf(label,"vibrafade"); break; 
-		case '7': sprintf(label,"tremolo"); break; 
-		case '8': sprintf(label,"pan"); break; 
-		case '9': sprintf(label,"smpstart"); break; 
-		case 'A': sprintf(label,"volfade"); break; 
-		case 'B': sprintf(label,"jump"); break; 
-		case 'C': sprintf(label,"vol"); break; 
-		case 'D': sprintf(label,"break"); break; 
-		case 'E': sprintf(label,"subcmd"); break; 
-		case 'F': sprintf(label,"bpm"); break; 
-		case 'G': sprintf(label,"gvol"); break; 
-		case 'H': sprintf(label,"gfade"); break; 
-		case 'K': sprintf(label,"keyoff"); break; 
-		case 'L': sprintf(label,"envpos"); break; 
-		case 'P': sprintf(label,"panslide"); break; 
-		case 'R': sprintf(label,"retrigfade"); break; 
-		case 'T': sprintf(label,"tremor"); break; 
-		case 'X': sprintf(label,"fineporta"); break; 
+		case '0': snprintf(label, sizeof(label),"arp"); break; 
+		case '1': snprintf(label, sizeof(label),"portup"); break; 
+		case '2': snprintf(label, sizeof(label),"portdown"); break; 
+		case '3': snprintf(label, sizeof(label),"portnote"); break; 
+		case '4': snprintf(label, sizeof(label),"vibrato"); break; 
+		case '5': snprintf(label, sizeof(label),"portafade"); break; 
+		case '6': snprintf(label, sizeof(label),"vibrafade"); break; 
+		case '7': snprintf(label, sizeof(label),"tremolo"); break; 
+		case '8': snprintf(label, sizeof(label),"pan"); break; 
+		case '9': snprintf(label, sizeof(label),"smpstart"); break; 
+		case 'A': snprintf(label, sizeof(label),"volfade"); break; 
+		case 'B': snprintf(label, sizeof(label),"jump"); break; 
+		case 'C': snprintf(label, sizeof(label),"vol"); break; 
+		case 'D': snprintf(label, sizeof(label),"break"); break; 
+		case 'E': snprintf(label, sizeof(label),"subcmd"); break; 
+		case 'F': snprintf(label, sizeof(label),"bpm"); break; 
+		case 'G': snprintf(label, sizeof(label),"gvol"); break; 
+		case 'H': snprintf(label, sizeof(label),"gfade"); break; 
+		case 'K': snprintf(label, sizeof(label),"keyoff"); break; 
+		case 'L': snprintf(label, sizeof(label),"envpos"); break; 
+		case 'P': snprintf(label, sizeof(label),"panslide"); break; 
+		case 'R': snprintf(label, sizeof(label),"retrigfade"); break; 
+		case 'T': snprintf(label, sizeof(label),"tremor"); break; 
+		case 'X': snprintf(label, sizeof(label),"fineporta"); break; 
 	}
 }

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -555,9 +555,9 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 	char buffer[32];
 	
 	if (offsetFormat == OffsetFormatHex)
-		sprintf(buffer, "%x", (mp_sint32)ceil(startPos*xScale));
+		snprintf(buffer, sizeof(buffer), "%x", (mp_sint32)ceil(startPos*xScale));
 	else if (offsetFormat == OffsetFormatDec)
-		sprintf(buffer, "%d", (mp_sint32)ceil(startPos*xScale));
+		snprintf(buffer, sizeof(buffer), "%d", (mp_sint32)ceil(startPos*xScale));
 	else if (offsetFormat == OffsetFormatMillis)
 	{
 		pp_uint32 millis = sampleEditor->convertSmpPosToMillis((mp_sint32)ceil(startPos*xScale), relativeNote);
@@ -579,9 +579,9 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 	if (currentPosition.x >= 0 && currentPosition.y >= 0)
 	{
 		if (offsetFormat == OffsetFormatHex)
-			sprintf(buffer, "%x / %x", positionToSample(currentPosition), end);
+			snprintf(buffer, sizeof(buffer), "%x / %x", positionToSample(currentPosition), end);
 		else if (offsetFormat == OffsetFormatDec)
-			sprintf(buffer, "%d / %d", positionToSample(currentPosition), end);
+			snprintf(buffer, sizeof(buffer), "%d / %d", positionToSample(currentPosition), end);
 		else if (offsetFormat == OffsetFormatMillis)
 		{
 			pp_uint32 millis = sampleEditor->convertSmpPosToMillis(positionToSample(currentPosition), relativeNote);
@@ -592,9 +592,9 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 	else
 	{
 		if (offsetFormat == OffsetFormatHex)
-			sprintf(buffer, "%x", end);
+			snprintf(buffer, sizeof(buffer), "%x", end);
 		else if (offsetFormat == OffsetFormatDec)
-			sprintf(buffer, "%d", end);
+			snprintf(buffer, sizeof(buffer), "%d", end);
 		else if (offsetFormat == OffsetFormatMillis)
 		{
 			pp_uint32 totalMillis = sampleEditor->convertSmpPosToMillis(end, relativeNote);
@@ -636,7 +636,7 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 				g->setPixel(offsetMarkerX, j + location.y);
 
 			// Draw value for 9xx command
-			sprintf(buffer, "Offset: %02x", currentOffset >> 8);
+			snprintf(buffer, sizeof(buffer), "Offset: %02x", currentOffset >> 8);
 
 			g->setColor(0, 0, 0);
 			g->drawString(buffer, location.x + 3 + visibleWidth - font->getStrWidth(buffer), location.y + font->getCharHeight() * 2 - 1);

--- a/src/tracker/SectionAdvancedEdit.cpp
+++ b/src/tracker/SectionAdvancedEdit.cpp
@@ -198,9 +198,9 @@ pp_int32 SectionAdvancedEdit::handleEvent(PPObject* sender, PPEvent* event)
 				}	
 
 				if (res)
-					sprintf(buffer, "%i commands have been converted", res);
+					snprintf(buffer, sizeof(buffer), "%i commands have been converted", res);
 				else
-					sprintf(buffer, "Nothing to do");
+					snprintf(buffer, sizeof(buffer), "Nothing to do");
 				
 				tracker.showMessageBox(MESSAGEBOX_UNIVERSAL, buffer, Tracker::MessageBox_OK);
 
@@ -221,9 +221,9 @@ pp_int32 SectionAdvancedEdit::handleEvent(PPObject* sender, PPEvent* event)
 				}	
 
 				if (res)
-					sprintf(buffer, "%i commands have been erased", res);
+					snprintf(buffer, sizeof(buffer), "%i commands have been erased", res);
 				else
-					sprintf(buffer, "Nothing to do");
+					snprintf(buffer, sizeof(buffer), "Nothing to do");
 				
 				tracker.showMessageBox(MESSAGEBOX_UNIVERSAL, buffer, Tracker::MessageBox_OK);
 	
@@ -414,7 +414,7 @@ void SectionAdvancedEdit::update(bool repaint/* = true*/)
 	
 	PPStaticText* text = static_cast<PPStaticText*>(container->getControlByID(ADVEDIT_TEXT_SPLITTRACK));
 
-	sprintf(buffer, "Use subsequent %02i channels", splitTrackNumSubsequentChannels);
+	snprintf(buffer, sizeof(buffer), "Use subsequent %02i channels", splitTrackNumSubsequentChannels);
 	
 	text->setText(buffer);
 

--- a/src/tracker/SectionDiskMenu.cpp
+++ b/src/tracker/SectionDiskMenu.cpp
@@ -818,7 +818,7 @@ void SectionDiskMenu::init(pp_int32 px, pp_int32 py)
 	{
 		pp_int32 buttonHeight = 11;
 		char temp[80];
-		sprintf(temp, "DIR%d", i+1);
+		snprintf(temp, sizeof(temp), "DIR%d", i+1);
 		PPFont* font = PPFont::getFont(PPFont::FONT_TINY);
 		button = new PPButton(DISKMENU_CLASSIC_BUTTON_DIR0+i, screen, this, PPPoint(x5, y5), PPSize(buttonWidth, buttonHeight));
 		button->setFont(font);
@@ -1929,7 +1929,7 @@ PPString SectionDiskMenu::getKeyFromPredefPathButton(PPControl* button)
 	
 		char result[1024];
 		
-		sprintf(result, "%s_%d", keys[classicViewState], id);
+		snprintf(result, sizeof(result), "%s_%d", keys[classicViewState], id);
 		
 		return PPString(result);
 	}

--- a/src/tracker/SectionHDRecorder.cpp
+++ b/src/tracker/SectionHDRecorder.cpp
@@ -434,7 +434,7 @@ void SectionHDRecorder::init(pp_int32 px, pp_int32 py)
 	for (pp_int32 j = 0; j < TrackerConfig::numMixFrequencies; j++)
 	{
 		char buffer[32];
-		sprintf(buffer, "%i Hz", TrackerConfig::mixFrequencies[j]);
+		snprintf(buffer, sizeof(buffer), "%i Hz", TrackerConfig::mixFrequencies[j]);
 		radioGroup->addItem(buffer);
 	}
 
@@ -649,7 +649,7 @@ void SectionHDRecorder::update(bool repaint/* = true*/)
 	PPSlider* slider = static_cast<PPSlider*>(container->getControlByID(HDRECORD_SLIDER_MIXERVOLUME));
 	ASSERT(slider);
 
-	sprintf(buffer, "%i%%", (mixerVolume*100)/256);
+	snprintf(buffer, sizeof(buffer), "%i%%", (mixerVolume*100)/256);
 
 	if (strlen(buffer) < 4)
 	{
@@ -705,11 +705,11 @@ void SectionHDRecorder::update(bool repaint/* = true*/)
 		staticText = static_cast<PPStaticText*>(container->getControlByID(HDRECORD_STATICTEXT_SAVETOFILENAME));
 		staticText->show(false);
 
-		sprintf(buffer, "Ins:%x", insIndex+1);
+		snprintf(buffer, sizeof(buffer), "Ins:%x", insIndex+1);
 		staticText = static_cast<PPStaticText*>(container->getControlByID(HDRECORD_STATICTEXT_INS));
 		staticText->setText(buffer);
 
-		sprintf(buffer, "Smp:%x", smpIndex);
+		snprintf(buffer, sizeof(buffer), "Smp:%x", smpIndex);
 		staticText = static_cast<PPStaticText*>(container->getControlByID(HDRECORD_STATICTEXT_SMP));
 		staticText->setText(buffer);
 		
@@ -808,7 +808,7 @@ void SectionHDRecorder::exportWAVAsFileName(const PPSystemString& fileName)
 	{
 		pp_int32 seconds = (pp_int32)((float)res / (float)getSettingsFrequency());
 		char buffer[200];
-		sprintf(buffer, "%i:%02i successfully recorded", seconds/60, seconds%60);
+		snprintf(buffer, sizeof(buffer), "%i:%02i successfully recorded", seconds/60, seconds%60);
 		tracker.showMessageBox(MESSAGEBOX_UNIVERSAL, buffer, Tracker::MessageBox_OK);
 	}
 	else

--- a/src/tracker/SectionInstruments.cpp
+++ b/src/tracker/SectionInstruments.cpp
@@ -413,8 +413,8 @@ pp_int32 SectionInstruments::handleEvent(PPObject* sender, PPEvent* event)
 				if (event->getID() != eCommand)
 					break;
 
-				sprintf(buffer, "Copy ins. %x to %x", tracker.listBoxInstruments->getSelectedIndex()+1, 1);
-				sprintf(buffer2, "Copy smp. %x to %x", tracker.listBoxSamples->getSelectedIndex(), 0);
+				snprintf(buffer, sizeof(buffer), "Copy ins. %x to %x", tracker.listBoxInstruments->getSelectedIndex()+1, 1);
+				snprintf(buffer2, sizeof(buffer2), "Copy smp. %x to %x", tracker.listBoxSamples->getSelectedIndex(), 0);
 
 				tracker.initInstrumentChooser(INSTRUMENT_CHOOSER_COPY, "Copy ins", "Copy smp", "Copy instrument/sample" PPSTR_PERIODS, 
 											  buffer, buffer2, 
@@ -431,8 +431,8 @@ pp_int32 SectionInstruments::handleEvent(PPObject* sender, PPEvent* event)
 				if (event->getID() != eCommand)
 					break;
 
-				sprintf(buffer, "Swap ins. %x with %x", tracker.listBoxInstruments->getSelectedIndex()+1, 1);
-				sprintf(buffer2, "Swap smp. %x with %x", tracker.listBoxSamples->getSelectedIndex(), 0);
+				snprintf(buffer, sizeof(buffer), "Swap ins. %x with %x", tracker.listBoxInstruments->getSelectedIndex()+1, 1);
+				snprintf(buffer2, sizeof(buffer2), "Swap smp. %x with %x", tracker.listBoxSamples->getSelectedIndex(), 0);
 
 				tracker.initInstrumentChooser(INSTRUMENT_CHOOSER_SWAP, "Swap ins", "Swap smp", "Swap instrument/sample" PPSTR_PERIODS, 
 											  buffer, buffer2, 
@@ -1492,9 +1492,9 @@ void SectionInstruments::update(bool repaint)
 
 #ifndef __LOWRES__ 
 	if (sampleEditor->getRelNoteNum() > 0)
-		sprintf(noteName,"    (+%i)",(pp_int32)sampleEditor->getRelNoteNum());
+		snprintf(noteName, sizeof(noteName),"    (+%i)",(pp_int32)sampleEditor->getRelNoteNum());
 	else
-		sprintf(noteName,"    (%i)",(pp_int32)sampleEditor->getRelNoteNum());
+		snprintf(noteName, sizeof(noteName),"    (%i)",(pp_int32)sampleEditor->getRelNoteNum());
 	PatternTools::getNoteName(noteName, sampleEditor->getRelNoteNum() + 4*12 + 1, false);
 #else
 	PatternTools::getNoteName(noteName, sampleEditor->getRelNoteNum() + 4*12 + 1);

--- a/src/tracker/SectionOptimize.cpp
+++ b/src/tracker/SectionOptimize.cpp
@@ -226,19 +226,19 @@ void SectionOptimize::optimize(bool evaluate/* = false*/)
 	if (removePatterns)
 	{
 		pp_int32 res = tracker.moduleEditor->removeUnusedPatterns(evaluate);
-		sprintf(buffer, "Unused patterns: %i", res);
+		snprintf(buffer, sizeof(buffer), "Unused patterns: %i", res);
 		listBox->addItem(buffer);
 	}
 	if (removeInstruments)
 	{
 		pp_int32 res = tracker.moduleEditor->removeUnusedInstruments(evaluate, remapInstruments);
-		sprintf(buffer, "Unused instruments: %i", res);
+		snprintf(buffer, sizeof(buffer), "Unused instruments: %i", res);
 		listBox->addItem(buffer);
 	}
 	if (removeSamples)
 	{
 		pp_int32 res = tracker.moduleEditor->removeUnusedSamples(evaluate);
-		sprintf(buffer, "Unused samples: %i", res);
+		snprintf(buffer, sizeof(buffer), "Unused samples: %i", res);
 		listBox->addItem(buffer);
 	}
 
@@ -248,13 +248,13 @@ void SectionOptimize::optimize(bool evaluate/* = false*/)
 		
 		if (minimizeSamples)
 		{
-			sprintf(buffer, "Minimized samples: %i", result.numMinimizedSamples);
+			snprintf(buffer, sizeof(buffer), "Minimized samples: %i", result.numMinimizedSamples);
 			listBox->addItem(buffer);
 		}
 
 		if (convertSamples)
 		{
-			sprintf(buffer, "Converted samples: %i", result.numConvertedSamples);
+			snprintf(buffer, sizeof(buffer), "Converted samples: %i", result.numConvertedSamples);
 			listBox->addItem(buffer);
 		}
 	}

--- a/src/tracker/SectionSettings.cpp
+++ b/src/tracker/SectionSettings.cpp
@@ -96,13 +96,13 @@ public:
 
 		char buffer[100];
 
-		sprintf(buffer, "R:%02X", getColor()->r);
+		snprintf(buffer, sizeof(buffer), "R:%02X", getColor()->r);
 		g->drawString(buffer, p.x, p.y, false);
 		p.y+=font->getCharHeight();
-		sprintf(buffer, "G:%02X", getColor()->g);
+		snprintf(buffer, sizeof(buffer), "G:%02X", getColor()->g);
 		g->drawString(buffer, p.x, p.y, false);
 		p.y+=font->getCharHeight();
-		sprintf(buffer, "B:%02X", getColor()->b);
+		snprintf(buffer, sizeof(buffer), "B:%02X", getColor()->b);
 		g->drawString(buffer, p.x, p.y, false);
 	}
 };
@@ -530,19 +530,19 @@ public:
 			if (fixed >= 100)
 			{
 				if (fixed >= 1000)
-					sprintf(buffer, "%i.%is(%i.%ik)", fixed / 1000, (fixed / 100) % 10, v / 1000, (v / 100) % 10);
+					snprintf(buffer, sizeof(buffer), "%i.%is(%i.%ik)", fixed / 1000, (fixed / 100) % 10, v / 1000, (v / 100) % 10);
 				else
-					sprintf(buffer, "%ims(%i.%ik)", fixed, v / 1000, (v / 100) % 10);
+					snprintf(buffer, sizeof(buffer), "%ims(%i.%ik)", fixed, v / 1000, (v / 100) % 10);
 			}
 			else
-				sprintf(buffer, "%i.%ims(%i.%ik)", fixed, decimal, v / 1000, (v / 100) % 10);
+				snprintf(buffer, sizeof(buffer), "%i.%ims(%i.%ik)", fixed, decimal, v / 1000, (v / 100) % 10);
 		}
 		else
 		{
 			if (fixed >= 1000)
-				sprintf(buffer, "%i.%is(%i)", fixed / 1000, (fixed / 100) % 10, v);
+				snprintf(buffer, sizeof(buffer), "%i.%is(%i)", fixed / 1000, (fixed / 100) % 10, v);
 			else
-				sprintf(buffer, "%i.%ims(%i)", fixed, decimal, v);
+				snprintf(buffer, sizeof(buffer), "%i.%ims(%i)", fixed, decimal, v);
 		}
 
 		if (strlen(buffer) < 9)
@@ -565,7 +565,7 @@ public:
 
 		v = settingsDatabase->restore("MIXERVOLUME")->getIntValue();
 
-		sprintf(buffer, "%i%%", (v*100)/256);
+		snprintf(buffer, sizeof(buffer), "%i%%", (v*100)/256);
 
 		if (strlen(buffer) < 4)
 		{
@@ -618,7 +618,7 @@ public:
 		for (j = 0; j < TrackerConfig::numMixFrequencies; j++)
 		{
 			char buffer[32];
-			sprintf(buffer, "%i Hz", TrackerConfig::mixFrequencies[j]);
+			snprintf(buffer, sizeof(buffer), "%i Hz", TrackerConfig::mixFrequencies[j]);
 			radioGroup->addItem(buffer);
 		}
 
@@ -742,7 +742,7 @@ public:
 		// buffersize
 		pp_int32 v = settingsDatabase->restore("VIRTUALCHANNELS")->getIntValue();
 
-		sprintf(buffer, "Use %02i", v);
+		snprintf(buffer, sizeof(buffer), "Use %02i", v);
 
 		text->setText(buffer);
 
@@ -829,8 +829,8 @@ public:
         PPDictionaryKey *k = settingsDatabase->restore("LIMITDRIVE");
         if( k != NULL ) v = k->getIntValue();
         char buffer[30];
-        if( v == 0 ) sprintf(buffer, "disabled");
-        else         sprintf(buffer, "Drive: +%i", v);
+        if( v == 0 ) snprintf(buffer, sizeof(buffer), "disabled");
+        else         snprintf(buffer, sizeof(buffer), "Drive: +%i", v);
         text->setText(buffer);
         slider->setCurrentValue(v);
 
@@ -940,7 +940,7 @@ public:
 
 		pp_int32 v = settingsDatabase->restore("SPACING")->getIntValue();
 		char buffer[100], buffer2[100];
-		sprintf(buffer,"%ipx", v);
+		snprintf(buffer, sizeof(buffer),"%ipx", v);
 		text->setText(buffer);
 		slider->setCurrentValue(v);
 
@@ -949,7 +949,7 @@ public:
 		slider = static_cast<PPSlider*>(container->getControlByID(SLIDER_MUTEFADE));
 
 		v = settingsDatabase->restore("MUTEFADE")->getIntValue();
-		sprintf(buffer, "%i%%", v);
+		snprintf(buffer, sizeof(buffer), "%i%%", v);
 		// right align
 		if (strlen(buffer) < 4)
 		{
@@ -963,13 +963,13 @@ public:
 		// update primary pattern row highlight
 		text = static_cast<PPStaticText*>(container->getControlByID(STATICTEXT_HIGHLIGHTMODULO1));
 		v = settingsDatabase->restore("HIGHLIGHTMODULO1")->getIntValue();
-		sprintf(buffer, "%02i ", v);
+		snprintf(buffer, sizeof(buffer), "%02i ", v);
 		text->setText(buffer);
 
 		// update secondary pattern row highlight
 		text = static_cast<PPStaticText*>(container->getControlByID(STATICTEXT_HIGHLIGHTMODULO2));
 		v = settingsDatabase->restore("HIGHLIGHTMODULO2")->getIntValue();
-		sprintf(buffer, "%02i ", v);
+		snprintf(buffer, sizeof(buffer), "%02i ", v);
 		text->setText(buffer);
 
 		v = settingsDatabase->restore("HIGHLIGHTROW1")->getIntValue();

--- a/src/tracker/SectionTranspose.cpp
+++ b/src/tracker/SectionTranspose.cpp
@@ -407,7 +407,7 @@ pp_int32 SectionTranspose::handleEvent(PPObject* sender, PPEvent* event)
 				}
 				
 				//char buffer[100];
-				//sprintf(buffer, "%i Notes have been transposed", res);
+				//snprintf(buffer, sizeof(buffer), "%i Notes have been transposed", res);
 				//tracker.showMessageBox(MESSAGEBOX_UNIVERSAL, buffer, Tracker::MessageBox_OK);
 				
 				tracker.screen->paint();
@@ -808,7 +808,7 @@ void SectionTranspose::update(bool repaint/* = true*/)
 
 	text = static_cast<PPStaticText*>(container->getControlByID(TRANSPOSE_TEXT_AMOUNT));
 	
-	sprintf(buffer, "%i", currentTransposeAmount);
+	snprintf(buffer, sizeof(buffer), "%i", currentTransposeAmount);
 
 	text->setText(buffer);
 
@@ -827,7 +827,7 @@ void SectionTranspose::handleTransposeSong()
 	else
 	{
 		char buffer[100];
-		sprintf(buffer, "%i notes will be erased, continue?", fuckups);
+		snprintf(buffer, sizeof(buffer), "%i notes will be erased, continue?", fuckups);
 		showMessageBox(MESSAGEBOX_TRANSPOSEPROCEED, buffer);
 	}
 }

--- a/src/tracker/Tracker.cpp
+++ b/src/tracker/Tracker.cpp
@@ -1380,10 +1380,10 @@ pp_int32 Tracker::handleEvent(PPObject* sender, PPEvent* event)
 				switch (container->getID())
 				{
 					case INSTRUMENT_CHOOSER_COPY:
-						sprintf(buffer, "Copy ins. %x to %x", listBoxSrcIns->getSelectedIndex()+1, listBoxDstIns->getSelectedIndex()+1);
+						snprintf(buffer, sizeof(buffer), "Copy ins. %x to %x", listBoxSrcIns->getSelectedIndex()+1, listBoxDstIns->getSelectedIndex()+1);
 						break;
 					case INSTRUMENT_CHOOSER_SWAP:
-						sprintf(buffer, "Swap ins. %x with %x", listBoxSrcSmp->getSelectedIndex()+1, listBoxDstSmp->getSelectedIndex()+1);
+						snprintf(buffer, sizeof(buffer), "Swap ins. %x with %x", listBoxSrcSmp->getSelectedIndex()+1, listBoxDstSmp->getSelectedIndex()+1);
 						break;
 				}
 
@@ -1435,13 +1435,13 @@ pp_int32 Tracker::handleEvent(PPObject* sender, PPEvent* event)
 				switch (container->getID())
 				{
 					case INSTRUMENT_CHOOSER_COPY:
-						sprintf(buffer, "Copy ins. %x to %x", listBoxSrc->getSelectedIndex()+1, listBoxDst->getSelectedIndex()+1);
+						snprintf(buffer, sizeof(buffer), "Copy ins. %x to %x", listBoxSrc->getSelectedIndex()+1, listBoxDst->getSelectedIndex()+1);
 						break;
 					case INSTRUMENT_CHOOSER_SWAP:
-						sprintf(buffer, "Swap ins. %x with %x", listBoxSrc->getSelectedIndex()+1, listBoxDst->getSelectedIndex()+1);
+						snprintf(buffer, sizeof(buffer), "Swap ins. %x with %x", listBoxSrc->getSelectedIndex()+1, listBoxDst->getSelectedIndex()+1);
 						break;
 					case MESSAGEBOX_INSREMAP:
-						sprintf(buffer, "Remap ins. %x to %x", listBoxSrc->getSelectedIndex()+1, listBoxDst->getSelectedIndex()+1);
+						snprintf(buffer, sizeof(buffer), "Remap ins. %x to %x", listBoxSrc->getSelectedIndex()+1, listBoxDst->getSelectedIndex()+1);
 						break;
 				}
 				
@@ -1463,10 +1463,10 @@ pp_int32 Tracker::handleEvent(PPObject* sender, PPEvent* event)
 				switch (container->getID())
 				{
 					case INSTRUMENT_CHOOSER_COPY:
-						sprintf(buffer, "Copy smp. %x to %x", listBoxSrc->getSelectedIndex(), listBoxDst->getSelectedIndex());
+						snprintf(buffer, sizeof(buffer), "Copy smp. %x to %x", listBoxSrc->getSelectedIndex(), listBoxDst->getSelectedIndex());
 						break;
 					case INSTRUMENT_CHOOSER_SWAP:
-						sprintf(buffer, "Swap smp. %x with %x", listBoxSrc->getSelectedIndex(), listBoxDst->getSelectedIndex());
+						snprintf(buffer, sizeof(buffer), "Swap smp. %x with %x", listBoxSrc->getSelectedIndex(), listBoxDst->getSelectedIndex());
 						break;
 				}
 				
@@ -2037,7 +2037,7 @@ bool Tracker::messageBoxEventListener(pp_int32 messageBoxID, pp_int32 messageBox
 					}
 					
 					char buffer[100];
-					sprintf(buffer, "%i Instruments have been remapped", res);
+					snprintf(buffer, sizeof(buffer), "%i Instruments have been remapped", res);
 					showMessageBox(MESSAGEBOX_UNIVERSAL, buffer, MessageBox_OK);
 					
 					screen->paint();

--- a/src/tracker/TrackerInit.cpp
+++ b/src/tracker/TrackerInit.cpp
@@ -1801,7 +1801,7 @@ void Tracker::initAdvEdit()
 
 	char buffer[100];
 
-	sprintf(buffer, "Remap ins. %x to %x", listBoxInstruments->getSelectedIndex()+1, 1);
+	snprintf(buffer, sizeof(buffer), "Remap ins. %x to %x", listBoxInstruments->getSelectedIndex()+1, 1);
 
 	//initInstrumentChooser(MESSAGEBOX_INSREMAP, "", "Instrument remapping", "",buffer, "",listBoxInstruments->getSelectedIndex());
 	// old instrument chooser / just inserted ;)

--- a/src/tracker/TrackerSettings.cpp
+++ b/src/tracker/TrackerSettings.cpp
@@ -100,7 +100,7 @@ void Tracker::buildDefaultSettings()
 	// ---------- Optimize --------
 	for (i = 0; i < (signed)SectionOptimize::getNumFlagGroups(); i++)
 	{
-		sprintf(buffer, "OPTIMIZER_%i",i);
+		snprintf(buffer, sizeof(buffer), "OPTIMIZER_%i",i);
 		settingsDatabase->store(buffer, SectionOptimize::getDefaultFlags(i));
 	}
 
@@ -236,14 +236,14 @@ void Tracker::buildDefaultSettings()
 	// Store volume envelopes
 	for (i = 0; i < TrackerConfig::numPredefinedEnvelopes; i++)
 	{
-		sprintf(buffer, "PREDEFENVELOPEVOLUME_%i",i);
+		snprintf(buffer, sizeof(buffer), "PREDEFENVELOPEVOLUME_%i",i);
 		settingsDatabase->store(buffer, TrackerConfig::defaultPredefinedVolumeEnvelope);
 	}
 
 	// Store panning envelopes
 	for (i = 0; i < TrackerConfig::numPredefinedEnvelopes; i++)
 	{
-		sprintf(buffer, "PREDEFENVELOPEPANNING_%i",i);
+		snprintf(buffer, sizeof(buffer), "PREDEFENVELOPEPANNING_%i",i);
 		settingsDatabase->store(buffer, TrackerConfig::defaultPredefinedPanningEnvelope);
 	}
 
@@ -257,14 +257,14 @@ void Tracker::buildDefaultSettings()
 
 	for (i = 0; i < NUMEFFECTMACROS; i++)
 	{
-		sprintf(buffer, "EFFECTMACRO_%i",i);
+		snprintf(buffer, sizeof(buffer), "EFFECTMACRO_%i",i);
 		settingsDatabase->store(buffer, 0);
 	}
 
 	// store predefined colorsets
 	for (i = 0; i < TrackerConfig::numPredefinedColorPalettes; i++)
 	{
-		sprintf(buffer, "PREDEFCOLORPALETTE_%i",i);
+		snprintf(buffer, sizeof(buffer), "PREDEFCOLORPALETTE_%i",i);
 		settingsDatabase->store(buffer, TrackerConfig::predefinedColorPalettes[i]);
 	}
 

--- a/src/tracker/TrackerShutDown.cpp
+++ b/src/tracker/TrackerShutDown.cpp
@@ -187,7 +187,7 @@ bool Tracker::shutDown()
 		// Optimizer
 		for (i = 0; i < (signed)SectionOptimize::getNumFlagGroups(); i++)
 		{
-			sprintf(buffer, "OPTIMIZER_%i",i);
+			snprintf(buffer, sizeof(buffer), "OPTIMIZER_%i",i);
 			settingsDatabase->store(buffer, sectionOptimize->getOptimizeCheckBoxFlags(i));
 		}
 
@@ -215,20 +215,20 @@ bool Tracker::shutDown()
 		// store predefined envelopes
 		for (i = 0; i < sectionInstruments->getNumPredefinedEnvelopes(); i++)
 		{
-			sprintf(buffer, "PREDEFENVELOPEVOLUME_%i",i);
+			snprintf(buffer, sizeof(buffer), "PREDEFENVELOPEVOLUME_%i",i);
 			settingsDatabase->store(buffer, sectionInstruments->getEncodedEnvelope(SectionInstruments::EnvelopeTypeVolume, i));
 		}
 
 		for (i = 0; i < sectionInstruments->getNumPredefinedEnvelopes(); i++)
 		{
-			sprintf(buffer, "PREDEFENVELOPEPANNING_%i",i);		
+			snprintf(buffer, sizeof(buffer), "PREDEFENVELOPEPANNING_%i",i);		
 			settingsDatabase->store(buffer, sectionInstruments->getEncodedEnvelope(SectionInstruments::EnvelopeTypePanning, i));
 		}
 
 		// store effect macros from pattern editor control
 		for (i = 0; i < NUMEFFECTMACROS; i++)
 		{
-			sprintf(buffer, "EFFECTMACRO_%i",i);
+			snprintf(buffer, sizeof(buffer), "EFFECTMACRO_%i",i);
 
 			pp_uint8 eff, op;
 			getPatternEditor()->getMacroOperands(i, eff, op);
@@ -240,7 +240,7 @@ bool Tracker::shutDown()
 
 		for (i = 0; i < sectionSettings->getNumPredefinedColorPalettes(); i++)
 		{
-			sprintf(buffer, "PREDEFCOLORPALETTE_%i",i);		
+			snprintf(buffer, sizeof(buffer), "PREDEFCOLORPALETTE_%i",i);		
 			settingsDatabase->store(buffer, sectionSettings->getEncodedPalette(i));
 		}
 

--- a/src/tracker/TrackerUpdate.cpp
+++ b/src/tracker/TrackerUpdate.cpp
@@ -221,7 +221,7 @@ bool Tracker::updatePlayTime()
 	pp_int32 minutes = (playtime / 60) % 60;
 	pp_int32 hours = (playtime / 3600) % 100;
 
-	sprintf(buffer,"%02i:%02i:%02i", hours, minutes, seconds);
+	snprintf(buffer, sizeof(buffer),"%02i:%02i:%02i", hours, minutes, seconds);
 
 	playtime = moduleEditor->getModuleServices()->getEstimatedSongLength();
 	if (playtime == -1)
@@ -246,7 +246,7 @@ bool Tracker::updatePlayTime()
 		pp_int32 seconds = playtime % 60;
 		pp_int32 minutes = (playtime / 60) % 60;
 		pp_int32 hours = (playtime / 3600) % 100;
-		sprintf(buffer2,"(%02i:%02i:%02i)", hours, minutes, seconds);
+		snprintf(buffer2, sizeof(buffer2),"(%02i:%02i:%02i)", hours, minutes, seconds);
 	}
 	
 	strcat(buffer, buffer2);

--- a/src/tracker/win32/PreferencesDialog.cpp
+++ b/src/tracker/win32/PreferencesDialog.cpp
@@ -258,9 +258,9 @@ void CPreferencesDialog::updateSliderVelocityAmplify()
 
 	TCHAR buffer[1024];
 #ifdef _UNICODE
-	wsprintf(buffer, _T("Record velocity (amplify: %i%%)"), m_dataBase->restore("VELOCITYAMPLIFY")->getIntValue());
+        wsprintf(buffer, _T("Record velocity (amplify: %i%%)"), m_dataBase->restore("VELOCITYAMPLIFY")->getIntValue());
 #else
-	sprintf(buffer, _T("Record velocity (amplify: %i%%)"), m_dataBase->restore("VELOCITYAMPLIFY")->getIntValue());
+        snprintf(buffer, sizeof(buffer), _T("Record velocity (amplify: %i%%)"), m_dataBase->restore("VELOCITYAMPLIFY")->getIntValue());
 #endif
 
 	SetWindowText(hWndToggle, buffer);

--- a/src/tracker/win32/Win32_main.cpp
+++ b/src/tracker/win32/Win32_main.cpp
@@ -468,9 +468,9 @@ static LONG WINAPI CrashHandler(EXCEPTION_POINTERS*)
 	{
 		_tcscpy(buffer, szPath);
 #ifdef _UNICODE
-		wsprintf(fileName, L"BACKUP%02i.XM", num);
+                wsprintf(fileName, L"BACKUP%02i.XM", num);
 #else
-		sprintf(fileName, "BACKUP%02i.XM", num);
+                snprintf(fileName, sizeof(fileName), "BACKUP%02i.XM", num);
 #endif
 		_tcscat(buffer, fileName);
 		num++;


### PR DESCRIPTION
## Summary
- eliminate compile warnings from `sprintf`
- use `snprintf` with buffer size instead

## Testing
- `cmake -B build` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6842d55039148329a5b20872c46179dd