### PR TITLE
Fix tautological pointer comparison in SampleEditor

### DIFF
--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -199,9 +199,9 @@ public:
 	void resetSelection() { selectionStart = selectionEnd = -1; }
 	pp_int32 getSelectionLength() const { return abs(selectionEnd - selectionStart); }
 	bool hasValidSelection() const { return ((selectionStart >= 0 && selectionEnd >= 0) && (selectionStart != selectionEnd)); }
-	bool wasGeneratedByMilkySynth() const { 
-		return sample != NULL && sample->name != NULL && sample->name[0] == 'M' && sample->name[1] == '1'; 
-	}
+        bool wasGeneratedByMilkySynth() const {
+                return sample != NULL && sample->name[0] == 'M' && sample->name[1] == '1';
+        }
 	
 	void selectAll();
 	void loopRange();


### PR DESCRIPTION
## Summary
- remove invalid `NULL` check on `sample->name`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842dc7178d4832992d227d7c314938c